### PR TITLE
修改了"Basic-Video-Call\One-to-One-Video\Agora-Windows-Tutorial-1to1"下的V…

### DIFF
--- a/One-to-One-Video/Agora-Windows-Tutorial-1to1/AgoraTutorial/AgoraTutorial.vcxproj
+++ b/One-to-One-Video/Agora-Windows-Tutorial-1to1/AgoraTutorial/AgoraTutorial.vcxproj
@@ -69,6 +69,9 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
+    <PostBuildEvent>
+      <Command>copy ..\sdk\dll\*.dll ..\Debug\</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>


### PR DESCRIPTION
…S配置，以达到将sdk 中两个dll 文件自动添加到指定文件夹下。更改之后，用户只需要将从官网下载的sdk 复制到与解决方案文件(.sln)夹同一个目录中即可运行程序，而不需要将sdk 中的两个动态库文件(.dll)复制到可执行文件的目录下。