### PR TITLE
Updated the problem that the dll dynamic link library could not be found

### DIFF
--- a/Group-Video/OpenVideoCall-Windows/OpenVideoCall/OpenVideoCall.vcxproj
+++ b/Group-Video/OpenVideoCall-Windows/OpenVideoCall/OpenVideoCall.vcxproj
@@ -116,6 +116,9 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
+    <PostBuildEvent>
+      <Command>copy ..\sdk\dll\*.dll ..\Debug</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/Group-Video/OpenVideoCall-Windows/OpenVideoCall/OpenVideoCall.vcxproj
+++ b/Group-Video/OpenVideoCall-Windows/OpenVideoCall/OpenVideoCall.vcxproj
@@ -117,7 +117,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>copy ..\sdk\dll\*.dll ..\Debug</Command>
+      <Command>copy ..\sdk\dll\*.dll ..\Debug\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/One-to-One-Video/Agora-Windows-Tutorial-1to1/AgoraTutorial/AgoraTutorial.vcxproj
+++ b/One-to-One-Video/Agora-Windows-Tutorial-1to1/AgoraTutorial/AgoraTutorial.vcxproj
@@ -72,6 +72,10 @@
     <PostBuildEvent>
       <Command>copy ..\sdk\dll\*.dll ..\Debug\</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>


### PR DESCRIPTION
    将sdk 中两个dll 文件自动添加到指定文件夹下，解决用户运行时 "找不到xxx.dll 文件" 的错误。更改之后，用户只需要将从官网下载的sdk 复制到与解决方案文件(.sln)夹同一个目录中即可运行程序，而不需要将sdk 中的两个动态库文件(.dll)复制到可执行文件的目录下。
    此次修改了Basic-Video-Call-master\One-to-One-Video\Agora-Windows-Tutorial-1to1 和 Basic-Video-Call-master\Group-Video\OpenVideoCall-Windows 文档下的教程